### PR TITLE
feat: add swap-send (MEV Batch Send) endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.venv/

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,236 @@
+# Platform Compatibility Guide
+
+This document covers which AI agent platforms support the Bitget Wallet Skill, how to install it on each, and the results of our verification testing.
+
+## Compatibility Rule
+
+Any AI agent that can **read files + execute Python + access the internet** can use this skill. The skill is self-contained — no external API keys or credentials are needed for testing.
+
+---
+
+## ✅ Tested & Verified Platforms
+
+### OpenClaw
+
+**Status:** ✅ Passed — Native support
+
+**What is it:** An open-source AI agent runtime that connects to Telegram, Discord, Slack, and more.
+
+**Installation:**
+```bash
+cd ~/.openclaw/workspace
+git submodule add https://github.com/bitget-wallet-ai-lab/bitget-wallet-skill.git skills/bitget-wallet
+```
+
+**How it works:** OpenClaw automatically detects `SKILL.md` in the `skills/` directory. The agent reads the skill instructions and calls the Python script directly when a user asks about crypto prices, token security, or swap quotes.
+
+**Test result:** The agent correctly queried SOL/ETH prices and ran USDC security audits with accurate, real-time data.
+
+---
+
+### Manus
+
+**Status:** ✅ Passed
+
+**What is it:** A general-purpose AI agent by Meta with full computer access (browser, terminal, file system). Runs tasks in a sandboxed Ubuntu environment.
+
+**Account setup:**
+1. Go to [manus.im](https://manus.im)
+2. Sign up with Google (free plan: 1,300 credits)
+
+**Installation:** Simply provide the GitHub URL in your prompt:
+
+> "Here's a skill for querying on-chain crypto data: https://github.com/bitget-wallet-ai-lab/bitget-wallet-skill — Install it and use it to get the current price of SOL, ETH, and run a security audit on USDC on Solana."
+
+**How it works:** Manus automatically (6 steps):
+1. Read the skill-creator guide and visited the GitHub repository
+2. Reviewed `SKILL.md` to understand API details and script instructions
+3. Cloned the repo to `/home/ubuntu/skills/bitget-wallet-skill/`
+4. Installed `requests` dependency
+5. Ran `python3 scripts/bitget_api.py token-price --chain sol --contract ""`
+6. Ran price query for ETH and security audit for USDC, then presented all results
+
+**Test result:**
+- SOL: $89.12 ✅
+- ETH: $2,065.74 ✅
+- USDC Audit: High Risk: No, 0 risks, 0 warnings, Buy/Sell Tax: 0%, Freeze/Mint Authority: No ✅
+- Verdict: "USDC on Solana passes the security audit with zero risk and zero warning flags."
+
+**Notes:** Manus completed all 6 steps autonomously and presented results in well-formatted tables. The skill was installed at `/home/ubuntu/skills/bitget-wallet-skill/` and is ready for future use. Free plan credits were sufficient.
+
+---
+
+### Bolt.new
+
+**Status:** ✅ Passed
+
+**What is it:** A web-based AI agent that builds full-stack applications from natural language prompts. Powered by Claude Sonnet.
+
+**Account setup:**
+1. Go to [bolt.new](https://bolt.new)
+2. Sign up with Google (free tier: 300K daily tokens)
+
+**Installation:** Provide the GitHub URL directly in the chat prompt:
+
+> "Here's a skill for querying on-chain crypto data: https://github.com/bitget-wallet-ai-lab/bitget-wallet-skill — Install it and use it to get the current price of SOL, ETH, and run a security audit on USDC on Solana."
+
+**How it works:** Bolt automatically:
+1. Fetched the repository and read `SKILL.md` and `README.md`
+2. Understood the API structure and available commands
+3. Installed the `requests` dependency
+4. Ran `python3 scripts/bitget_api.py token-price --chain sol --contract ""`
+5. Presented results in a formatted web UI
+
+**Test result:**
+- SOL: $85.25 ✅
+- ETH: $1,993.73 ✅
+- USDC Audit: PASSED — 0 risks, 0 warnings, Freeze/Mint Authority disabled ✅
+
+**Notes:** Bolt also built a web frontend to display the results, which goes beyond the basic skill usage. Free tier was sufficient for the full test.
+
+---
+
+### Devin
+
+**Status:** ✅ Passed
+
+**What is it:** An AI software engineer by Cognition that can clone repos, write code, run commands, and create pull requests.
+
+**Account setup:**
+1. Go to [app.devin.ai/signup](https://app.devin.ai/signup)
+2. Sign up with Google (free trial: 5.0 ACUs)
+
+**Installation:** Enter the task in Devin's chat:
+
+> "Clone https://github.com/bitget-wallet-ai-lab/bitget-wallet-skill and use it to: 1) Get current price of SOL 2) Get current price of ETH 3) Run security audit on USDC on Solana (contract: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v). Show all results."
+
+**How it works:** Devin automatically:
+1. Read `SKILL.md` (lines 1–77) and `README.md` (lines 1–154)
+2. Cloned the bitget-wallet-skill repository
+3. Ran `pip install requests`
+4. Executed three commands sequentially:
+   - `python3 scripts/bitget_api.py token-price --chain sol --contract ""`
+   - `python3 scripts/bitget_api.py token-price --chain eth --contract ""`
+   - `python3 scripts/bitget_api.py security --chain sol --contract EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+5. Parsed JSON output and presented structured results
+
+**Test result:**
+- SOL: $85.98 ✅
+- ETH: $2,009.69 ✅
+- USDC Audit: High Risk: No, 0 risks, 0 warnings, Buy/Sell Tax: 0% ✅
+- Verdict: "USDC on Solana passes the security audit cleanly — no risks or warnings detected."
+
+**Notes:** Devin's approach was methodical — it read the documentation first, then executed commands step by step. The free trial was sufficient for the full test.
+
+---
+
+### Replit Agent
+
+**Status:** ✅ Passed
+
+**What is it:** An AI agent built into Replit that can create full applications from natural language descriptions.
+
+**Account setup:**
+1. Go to [replit.com](https://replit.com)
+2. Sign up with Google (free Starter plan)
+
+**Installation:** Enter the prompt on the Replit home page:
+
+> "Here's a skill for querying on-chain crypto data: https://github.com/bitget-wallet-ai-lab/bitget-wallet-skill — Install it and use it to get the price of SOL, ETH, and run a security audit on USDC on Solana."
+
+**How it works:** Replit Agent automatically:
+1. Created a new project called "Crypto Data Query"
+2. Cloned the skill repository
+3. Set up Python environment and installed dependencies
+4. Ran all three query commands
+5. Built a complete web application to display the results
+
+**Test result:**
+- SOL: $85.30 ✅
+- ETH: $1,990.14 ✅
+- USDC Audit: Security Status: EXCELLENT (No Risks Found), Freeze/Mint Authority: Disabled ✓ ✅
+- "The USDC token on Solana appears to be legitimate and secure with no concerning security issues."
+
+**Notes:** Replit went further than expected — it not only ran the skill but built a full web app around it with a polished UI. Used about 33% of the free Starter plan's agent credits for the entire test.
+
+---
+
+## 🔧 Compatible Platforms (Not Yet Tested)
+
+These platforms have the required capabilities (file system access, Python execution, network access) and should work with this skill.
+
+### CLI Agents
+
+| Platform | How to Use |
+|----------|------------|
+| **Claude Code** | Clone repo into your project. The agent can read `SKILL.md` and execute scripts directly. |
+| **Codex CLI (OpenAI)** | Clone repo, reference the skill in `AGENTS.md`. Codex will discover and use the scripts. |
+| **Aider** | Add the scripts directory to your project. Aider can execute Python commands. |
+
+### IDE Agents
+
+| Platform | How to Use |
+|----------|------------|
+| **Cursor** | Clone into project directory, or use the [MCP version](https://github.com/bitget-wallet-ai-lab/bitget-wallet-mcp) for native tool integration. |
+| **Windsurf** | Same as Cursor — clone or use MCP version. |
+| **Cline (VS Code)** | Clone into workspace. Cline can read files and run terminal commands. |
+| **Continue (VS Code / JetBrains)** | Clone into project, or configure MCP server. |
+
+### Coding Agents
+
+| Platform | How to Use |
+|----------|------------|
+| **OpenHands** | The Docker sandbox provides a full Linux environment. Clone and run directly. |
+| **SWE-agent** | Has shell access — clone the repo and execute scripts. |
+
+### Workflow / Low-Code Platforms
+
+| Platform | How to Use |
+|----------|------------|
+| **Dify** | Import `bitget_api.py` as a Code node, or wrap as an external API Tool. |
+| **Coze (扣子)** | Create a plugin with the API endpoints, or use the script as a Code block. |
+| **n8n** | Use the AI Agent node with a code execution step. |
+| **Langflow / Flowise** | Wrap as a custom tool in the visual workflow builder. |
+
+### Frameworks
+
+| Framework | How to Use |
+|-----------|------------|
+| **LangChain / LangGraph** | Import `bitget_api.py` functions as a `Tool`. |
+| **CrewAI** | Wrap as a custom `Tool` class for your crew agents. |
+| **AutoGen (Microsoft)** | Register as a function call tool. |
+| **Semantic Kernel** | Import as a native function plugin. |
+
+---
+
+## 🔗 Alternative Integrations
+
+For platforms that don't support direct file execution, use these alternatives:
+
+| Need | Solution |
+|------|----------|
+| MCP-compatible agents (Claude Desktop, Cursor, Windsurf) | Use [bitget-wallet-mcp](https://github.com/bitget-wallet-ai-lab/bitget-wallet-mcp) |
+| Terminal / CLI usage | Use [bitget-wallet-cli](https://github.com/bitget-wallet-ai-lab/bitget-wallet-cli) |
+| REST API integration | Deploy the MCP server with SSE transport |
+
+---
+
+## Testing Methodology
+
+All verified platforms were tested with the same prompt to ensure consistency:
+
+> "Here's a skill for querying on-chain crypto data: https://github.com/bitget-wallet-ai-lab/bitget-wallet-skill
+>
+> Please install this skill and use it to:
+> 1. Get the current price of SOL
+> 2. Get the current price of ETH
+> 3. Run a security audit on USDC on Solana (contract: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)
+>
+> Show me all the results."
+
+**Evaluation criteria:**
+- ✅ Agent independently reads documentation and understands the skill
+- ✅ Agent installs dependencies without manual guidance
+- ✅ Agent executes correct commands with proper arguments
+- ✅ Returned data is accurate and matches real-time market data
+- ✅ Security audit results are consistent across platforms

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bitget Wallet Dev Pub Agent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,200 @@
+# Bitget Wallet ToB API Skill
+
+## Overview
+
+An AI Agent skill that wraps the [Bitget Wallet ToB API](https://web3.bitget.com/en/docs), enabling natural-language-driven on-chain data queries and swap operations.
+
+### Core Capabilities
+
+| Capability | Description | Example |
+|------------|-------------|---------|
+| **Token Info** | Price, market cap, holders, social links | "What's the price of SOL?" |
+| **Batch Price Query** | Multi-token price lookup in one call | Portfolio valuation |
+| **K-line Data** | 1m/5m/1h/4h/1d candlestick data | Trend analysis, charting |
+| **Transaction Stats** | 5m/1h/4h/24h buy/sell volume & trader count | Activity detection, whale monitoring |
+| **Rankings** | Top gainers / top losers | Market scanning, alpha discovery |
+| **Liquidity Pools** | LP pool information | Slippage estimation, depth analysis |
+| **Security Audit** | Contract safety checks (honeypot, permissions, blacklist) | Pre-trade risk control |
+| **Batch Tx Info** | Batch transaction statistics for multiple tokens | "Compare volume for SOL and ETH" |
+| **Historical Coins** | Discover new tokens by timestamp | "What tokens launched today?" |
+| **Swap Quote** | Best-route quote for cross-chain/same-chain swaps | "How much USDC for 1 SOL?" |
+| **Swap Calldata** | Generate unsigned transaction data | Execute trades via wallet signing |
+
+### Supported Chains
+
+Ethereum · Solana · BNB Chain · Base · Arbitrum · Tron · TON · Sui · Optimism and more.
+
+---
+
+## Architecture
+
+```
+Natural Language Input
+    ↓
+AI Agent (OpenClaw / Dify / Custom)
+    ↓
+bitget_api.py (Python 3.11+)
+    ↓  ← Built-in demo keys or env var override
+HMAC-SHA256 Signing
+    ↓
+Bitget Wallet ToB API (bopenapi.bgwapi.io)
+    ↓
+Structured JSON → Agent interprets → Natural language response
+```
+
+**Security by Design:**
+- Built-in demo credentials are public read-only API keys (safe to share)
+- For production use, override with your own keys via `BGW_API_KEY` / `BGW_API_SECRET` env vars
+- Swap calldata only generates transaction data; **actual signing requires wallet confirmation** (prevents unauthorized transactions)
+
+---
+
+## Agent Use Cases
+
+### 1. Personal Research Assistant
+> "Check if this Solana meme coin is safe, and give me a price quote."
+
+- Token info + security audit + price in a single query
+- For: individual traders, researchers
+- Platforms: Telegram Bot, Discord Bot, OpenClaw
+
+### 2. Portfolio Management Agent
+> "What's my total portfolio value right now?"
+
+- Batch query across chains and tokens, calculate net value
+- Scheduled snapshots + K-line data for historical tracking
+- For: DeFi users, fund managers
+- Platforms: OpenClaw cron + Telegram alerts
+
+### 3. Market Monitoring / Alert Agent
+> Automatically scan top gainers, detect anomalies, push alerts
+
+- Rankings + transaction volume + security audit combined
+- Discover trending tokens → auto-run security audit → filter honeypots → notify user
+- For: on-chain alpha hunters
+- Platforms: Cron jobs, Dify workflows
+
+### 4. Semi-Automated Trading Agent
+> "Buy this token with 1 SOL"
+
+- Swap quote → show route and slippage → user confirms → generate calldata → wallet signs
+- **Human-in-the-loop** — the agent cannot sign independently
+- For: active traders wanting an AI assistant
+- Platforms: OpenClaw + Bitget Wallet App / hardware wallet
+
+### 5. Arbitrage Bot Data Layer
+> Monitor DEX price discrepancies, discover cross-chain arbitrage opportunities
+
+- Multi-chain swap-quote comparison, calculate spreads
+- Combine with CEX data for DEX-CEX spread monitoring
+- For: quant teams
+- Platforms: Custom Python scripts, OpenClaw sub-agents
+
+### 6. Community Service Bot
+> Someone asks "How much is XX coin?" in a group chat — bot auto-replies
+
+- Lightweight queries, fast response
+- Security audit feature doubles as anti-scam protection
+- For: Telegram/Discord communities
+- Platforms: Telegram Bot + OpenClaw skill
+
+### 7. Dify / LangChain Tool Node
+> Integrate as a Tool in Dify workflows or LangChain agents
+
+- `bitget_api.py` can serve directly as a Dify Code node or external API Tool
+- Can also be wrapped as an MCP Server for any MCP-compatible agent framework
+- For: enterprise agent platform integration
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+1. Python 3.11+
+2. `requests` library (`pip install requests`)
+3. That's it — public demo API credentials are built in. To use your own keys, set `BGW_API_KEY` and `BGW_API_SECRET` env vars.
+
+> **Note:** The built-in demo keys are for testing purposes and may change over time. If they stop working, please update the skill (`git pull`) to get the latest keys.
+
+### Examples
+
+```bash
+# Get SOL price
+python3 scripts/bitget_api.py token-price --chain sol --contract ""
+
+# Security audit for a token
+python3 scripts/bitget_api.py security --chain sol --contract <contract_address>
+
+# Swap quote (1 SOL → USDC)
+python3 scripts/bitget_api.py swap-quote \
+  --from-chain sol --from-contract "" \
+  --to-contract EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
+  --amount 1
+```
+
+---
+
+## Future Directions
+
+| Direction | Description |
+|-----------|-------------|
+| **MCP Server Wrapper** | Package as a standard MCP Tool for Claude / Dify / any MCP client |
+| **On-chain Event Subscription** | WebSocket listeners for large transactions, new pool creation |
+| **Historical Data Cache** | Store K-line + price data in local SQLite to reduce API calls |
+| **Multi-wallet Management** | Support multi-address balance queries and batch quotes |
+| **Risk Rule Engine** | Security audit results + custom rules (blacklist, min liquidity thresholds) |
+
+---
+
+## Compatible Platforms
+
+### ✅ Tested & Verified
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| [OpenClaw](https://openclaw.ai) | ✅ Passed | Native skill support |
+| [Manus](https://manus.im) | ✅ Passed | Auto-installed and executed |
+| [Bolt.new](https://bolt.new) | ✅ Passed | Auto-cloned repo, ran all commands |
+| [Devin](https://devin.ai) | ✅ Passed | Read SKILL.md, installed deps, returned correct data |
+| [Replit Agent](https://replit.com) | ✅ Passed | Full project setup with web frontend |
+
+### 🔧 Should Work (file system + Python + network access)
+
+| Platform | Type | How to Use |
+|----------|------|------------|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | CLI Agent | Clone repo, add SKILL.md to project context |
+| [Codex CLI](https://github.com/openai/codex) | CLI Agent | Clone repo, reference in AGENTS.md |
+| [Cursor](https://cursor.com) | IDE Agent | Clone into project, or use [MCP version](https://github.com/bitget-wallet-ai-lab/bitget-wallet-mcp) |
+| [Windsurf](https://codeium.com/windsurf) | IDE Agent | Clone into project, or use [MCP version](https://github.com/bitget-wallet-ai-lab/bitget-wallet-mcp) |
+| [Cline](https://github.com/cline/cline) | VS Code Agent | Clone into project workspace |
+| [Aider](https://aider.chat) | CLI Agent | Add scripts to project |
+| [OpenHands](https://github.com/All-Hands-AI/OpenHands) | Coding Agent | Docker sandbox with full file system |
+| [SWE-agent](https://github.com/princeton-nlp/SWE-agent) | Coding Agent | Shell access in sandbox |
+| [Dify](https://dify.ai) | Workflow Platform | Use as Code node or external API Tool |
+| [Coze](https://www.coze.com) | Agent Platform | Import as plugin or API Tool |
+| [LangChain](https://langchain.com) / [CrewAI](https://crewai.com) | Frameworks | Wrap `bitget_api.py` as a Tool |
+
+### 💡 Compatibility Rule
+
+Any AI agent that can **read files + run Python + access the internet** should work with this skill.
+
+---
+
+## Related Projects
+
+- [bitget-wallet-mcp](https://github.com/bitget-wallet-ai-lab/bitget-wallet-mcp) — MCP Server for Claude Desktop / Cursor / Windsurf
+- [bitget-wallet-cli](https://github.com/bitget-wallet-ai-lab/bitget-wallet-cli) — CLI tool for terminal users
+
+---
+
+## Security Notes
+
+- Built-in demo API keys are public and read-only; for production, use env vars (`BGW_API_KEY` / `BGW_API_SECRET`)
+- Swap functions only generate quotes and transaction data — **no autonomous signing capability**
+- Large operations require explicit user confirmation (human-in-the-loop)
+- Always run a security audit (`security` command) before interacting with any token
+
+## License
+
+MIT

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: bitget-wallet
+description: "Interact with Bitget Wallet ToB API for crypto market data, token info, swap quotes, and security audits. Use when the user asks about token prices, market data, swap/trading quotes, token security checks, K-line charts, or token rankings on supported chains (ETH, SOL, BSC, Base, etc.)."
+---
+
+# Bitget Wallet ToB API
+
+## API Overview
+
+- **Base URL**: `https://bopenapi.bgwapi.io`
+- **Auth**: HMAC-SHA256 signature with appId + apiSecret
+- **All requests**: POST with JSON body
+- **Credentials**: Built-in public demo credentials (works out of the box). Override with `BGW_API_KEY` / `BGW_API_SECRET` env vars for your own keys.
+- **Partner-Code**: `bgw_swap_public` (for swap endpoints)
+
+## Scripts
+
+All scripts are in `scripts/` and use Python 3.11+. No external credential setup needed — demo API keys are built in.
+
+### `scripts/bitget_api.py` — Unified API Client
+
+```bash
+# Token info (price, supply, holders, socials)
+python3 scripts/bitget_api.py token-info --chain sol --contract <address>
+
+# Token price only
+python3 scripts/bitget_api.py token-price --chain sol --contract <address>
+
+# Batch token info (comma-separated)
+python3 scripts/bitget_api.py batch-token-info --tokens "sol:<addr1>,eth:<addr2>"
+
+# K-line data
+python3 scripts/bitget_api.py kline --chain sol --contract <address> --period 1h --size 24
+
+# Token transaction info (5m/1h/4h/24h volume, buyers, sellers)
+python3 scripts/bitget_api.py tx-info --chain sol --contract <address>
+
+# Token rankings (topGainers / topLosers)
+python3 scripts/bitget_api.py rankings --name topGainers
+
+# Token liquidity pools
+python3 scripts/bitget_api.py liquidity --chain sol --contract <address>
+
+# Security audit
+python3 scripts/bitget_api.py security --chain sol --contract <address>
+
+# Swap quote (amount = human-readable, e.g. 1 = 1 SOL, NOT lamports; toAmount likewise)
+python3 scripts/bitget_api.py swap-quote --from-chain sol --from-contract <addr> --to-contract <addr> --amount 1
+
+# Swap calldata (returns tx data for signing)
+python3 scripts/bitget_api.py swap-calldata --from-chain sol --from-contract <addr> --to-contract <addr> --amount 1 --from-address <wallet> --to-address <wallet> --market <market>
+```
+
+### Chain Identifiers
+
+| Chain | ID | Code |
+|-------|------|------|
+| Ethereum | 1 | eth |
+| Solana | 100278 | sol |
+| BNB Chain | 56 | bnb |
+| Base | 8453 | base |
+| Arbitrum | 42161 | arbitrum |
+| Tron | 6 | trx |
+| Ton | 100280 | ton |
+| Sui | 100281 | suinet |
+| Optimism | 10 | optimism |
+
+Use empty string `""` for native tokens (ETH, SOL, BNB, etc.).
+
+## Safety Rules
+
+- Built-in demo keys are public; if using custom keys via env vars, avoid exposing them in output
+- Swap API uses `Partner-Code: bgw_swap_public` header (hardcoded in script)
+- Swap calldata is for **information only** — actual signing requires wallet interaction
+- For large trades, always show the quote first and ask for user confirmation
+- Present security audit results before recommending any token action

--- a/scripts/bitget_api.py
+++ b/scripts/bitget_api.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+Bitget Wallet ToB API client.
+Built-in demo credentials or override via env vars.
+"""
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import sys
+import time
+import requests
+
+BASE_URL = "https://bopenapi.bgwapi.io"
+
+# Public demo credentials for testing purposes. These may change over time —
+# if they stop working, please update the skill to get the latest keys.
+# Override via BGW_API_KEY / BGW_API_SECRET env vars.
+DEFAULT_API_KEY = "4843D8C3F1E20772C0E634EDACC5C5F9A0E2DC92"
+DEFAULT_API_SECRET = "F2ABFDC684BDC6775FD6286B8D06A3AAD30FD587"
+
+
+def get_credentials():
+    """Load appId and apiSecret from env vars or use built-in defaults."""
+    api_key = os.environ.get("BGW_API_KEY", DEFAULT_API_KEY)
+    api_secret = os.environ.get("BGW_API_SECRET", DEFAULT_API_SECRET)
+    return api_key, api_secret
+
+
+def sign_request(api_path, body_str, api_key, api_secret, timestamp, query_params=None):
+    """Generate HMAC-SHA256 signature per Bitget Wallet docs."""
+    content = {
+        "apiPath": api_path,
+        "body": body_str,
+        "x-api-key": api_key,
+        "x-api-timestamp": timestamp,
+    }
+    if query_params:
+        for k, v in query_params.items():
+            content[k] = str(v)
+
+    # Sort keys alphabetically
+    sorted_content = dict(sorted(content.items()))
+    payload = json.dumps(sorted_content, separators=(',', ':'))
+
+    sig = hmac.new(api_secret.encode(), payload.encode(), hashlib.sha256).digest()
+    return base64.b64encode(sig).decode()
+
+
+DEFAULT_PARTNER_CODE = "bgw_swap_public"
+
+
+def api_request(path, body=None):
+    """Make authenticated API request."""
+    api_key, api_secret = get_credentials()
+    timestamp = str(int(time.time() * 1000))
+    body_str = json.dumps(body, separators=(',', ':'), sort_keys=True) if body else ""
+
+    signature = sign_request(path, body_str, api_key, api_secret, timestamp)
+
+    url = BASE_URL + path
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+        "x-api-timestamp": timestamp,
+        "x-api-signature": signature,
+    }
+    # Swap endpoints require Partner-Code header
+    if "/swapx/" in path:
+        headers["Partner-Code"] = os.environ.get("BGW_PARTNER_CODE", DEFAULT_PARTNER_CODE)
+
+    try:
+        resp = requests.post(url, data=body_str if body_str else None, headers=headers, timeout=30)
+        if resp.status_code != 200:
+            return {"error": f"HTTP {resp.status_code}", "message": resp.text[:500]}
+        return resp.json()
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _get_single_token_info(chain, contract):
+    """Get single token info via batchGetBaseInfo (getBaseInfo returns 400)."""
+    body = {"list": [{"chain": chain, "contract": contract}]}
+    result = api_request("/bgw-pro/market/v3/coin/batchGetBaseInfo", body)
+    if "data" in result and "list" in result["data"] and result["data"]["list"]:
+        return {"data": result["data"]["list"][0], "status": result.get("status", 0)}
+    return result
+
+
+def cmd_token_info(args):
+    result = _get_single_token_info(args.chain, args.contract)
+    print(json.dumps(result, indent=2))
+
+
+def cmd_token_price(args):
+    result = _get_single_token_info(args.chain, args.contract)
+    if "data" in result:
+        d = result["data"]
+        print(json.dumps({
+            "symbol": d.get("symbol"),
+            "name": d.get("name"),
+            "price": d.get("price"),
+            "chain": args.chain,
+            "contract": args.contract,
+        }, indent=2))
+    else:
+        print(json.dumps(result, indent=2))
+
+
+def cmd_batch_token_info(args):
+    tokens = []
+    for item in args.tokens.split(","):
+        chain, contract = item.strip().split(":", 1)
+        tokens.append({"chain": chain, "contract": contract})
+    body = {"list": tokens}
+    print(json.dumps(api_request("/bgw-pro/market/v3/coin/batchGetBaseInfo", body), indent=2))
+
+
+def cmd_kline(args):
+    body = {"chain": args.chain, "contract": args.contract, "period": args.period, "size": args.size}
+    print(json.dumps(api_request("/bgw-pro/market/v3/coin/getKline", body), indent=2))
+
+
+def cmd_tx_info(args):
+    body = {"chain": args.chain, "contract": args.contract}
+    print(json.dumps(api_request("/bgw-pro/market/v3/coin/getTxInfo", body), indent=2))
+
+
+def cmd_batch_tx_info(args):
+    """Batch get transaction statistics for multiple tokens."""
+    tokens = []
+    for item in args.tokens.split(","):
+        chain, contract = item.strip().split(":", 1)
+        tokens.append({"chain": chain, "contract": contract})
+    body = {"list": tokens}
+    print(json.dumps(api_request("/bgw-pro/market/v3/coin/batchGetTxInfo", body), indent=2))
+
+
+def cmd_historical_coins(args):
+    """Get token list by timestamp (paginated)."""
+    body = {"createTime": args.create_time, "limit": args.limit}
+    print(json.dumps(api_request("/bgw-pro/market/v3/historical-coins", body), indent=2))
+
+
+def cmd_rankings(args):
+    body = {"name": args.name}
+    print(json.dumps(api_request("/bgw-pro/market/v3/topRank/detail", body), indent=2))
+
+
+def cmd_liquidity(args):
+    body = {"chain": args.chain, "contract": args.contract}
+    print(json.dumps(api_request("/bgw-pro/market/v3/poolList", body), indent=2))
+
+
+def cmd_security(args):
+    body = {
+        "list": [{"chain": args.chain, "contract": args.contract}],
+        "source": "bg"
+    }
+    print(json.dumps(api_request("/bgw-pro/market/v3/coin/security/audits", body), indent=2))
+
+
+def cmd_swap_quote(args):
+    body = {
+        "fromChain": args.from_chain,
+        "fromContract": args.from_contract,
+        "toChain": args.to_chain or args.from_chain,
+        "toContract": args.to_contract,
+        "fromAmount": str(args.amount),
+        "estimateGas": True,
+    }
+    if args.from_symbol:
+        body["fromSymbol"] = args.from_symbol
+    if args.to_symbol:
+        body["toSymbol"] = args.to_symbol
+    if args.from_address:
+        body["fromAddress"] = args.from_address
+    print(json.dumps(api_request("/bgw-pro/swapx/pro/quote", body), indent=2))
+
+
+def cmd_swap_calldata(args):
+    body = {
+        "fromChain": args.from_chain,
+        "fromContract": args.from_contract,
+        "toChain": args.to_chain or args.from_chain,
+        "toContract": args.to_contract,
+        "fromAmount": str(args.amount),
+        "fromAddress": args.from_address,
+        "toAddress": args.to_address,
+        "market": args.market,
+    }
+    if args.from_symbol:
+        body["fromSymbol"] = args.from_symbol
+    if args.to_symbol:
+        body["toSymbol"] = args.to_symbol
+    if args.slippage:
+        body["slippage"] = args.slippage
+    print(json.dumps(api_request("/bgw-pro/swapx/pro/swap", body), indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bitget Wallet ToB API Client")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # token-info
+    p = sub.add_parser("token-info", help="Get token info")
+    p.add_argument("--chain", required=True)
+    p.add_argument("--contract", required=True)
+    p.set_defaults(func=cmd_token_info)
+
+    # token-price
+    p = sub.add_parser("token-price", help="Get token price")
+    p.add_argument("--chain", required=True)
+    p.add_argument("--contract", required=True)
+    p.set_defaults(func=cmd_token_price)
+
+    # batch-token-info
+    p = sub.add_parser("batch-token-info", help="Batch get token info")
+    p.add_argument("--tokens", required=True, help="chain:contract,chain:contract,...")
+    p.set_defaults(func=cmd_batch_token_info)
+
+    # kline
+    p = sub.add_parser("kline", help="Get K-line data")
+    p.add_argument("--chain", required=True)
+    p.add_argument("--contract", required=True)
+    p.add_argument("--period", default="1h", help="1s,1m,5m,15m,30m,1h,4h,1d,1w")
+    p.add_argument("--size", type=int, default=24, help="Max 1440")
+    p.set_defaults(func=cmd_kline)
+
+    # tx-info
+    p = sub.add_parser("tx-info", help="Get token transaction info")
+    p.add_argument("--chain", required=True)
+    p.add_argument("--contract", required=True)
+    p.set_defaults(func=cmd_tx_info)
+
+    # batch-tx-info
+    p = sub.add_parser("batch-tx-info", help="Batch get token transaction info")
+    p.add_argument("--tokens", required=True, help="Comma-separated chain:contract pairs")
+    p.set_defaults(func=cmd_batch_tx_info)
+
+    # historical-coins
+    p = sub.add_parser("historical-coins", help="Get token list by timestamp")
+    p.add_argument("--create-time", required=True, help="Timestamp (e.g. 2025-06-17 06:55:28)")
+    p.add_argument("--limit", type=int, default=10, help="Number of records (default 10)")
+    p.set_defaults(func=cmd_historical_coins)
+
+    # rankings
+    p = sub.add_parser("rankings", help="Get token rankings")
+    p.add_argument("--name", required=True, help="topGainers or topLosers")
+    p.set_defaults(func=cmd_rankings)
+
+    # liquidity
+    p = sub.add_parser("liquidity", help="Get token liquidity info")
+    p.add_argument("--chain", required=True)
+    p.add_argument("--contract", required=True)
+    p.set_defaults(func=cmd_liquidity)
+
+    # security
+    p = sub.add_parser("security", help="Security audit")
+    p.add_argument("--chain", required=True)
+    p.add_argument("--contract", required=True)
+    p.set_defaults(func=cmd_security)
+
+    # swap-quote
+    p = sub.add_parser("swap-quote", help="Get swap quote")
+    p.add_argument("--from-chain", required=True)
+    p.add_argument("--from-contract", required=True)
+    p.add_argument("--to-chain")
+    p.add_argument("--to-contract", required=True)
+    p.add_argument("--amount", required=True)
+    p.add_argument("--from-symbol")
+    p.add_argument("--to-symbol")
+    p.add_argument("--from-address")
+    p.set_defaults(func=cmd_swap_quote)
+
+    # swap-calldata
+    p = sub.add_parser("swap-calldata", help="Get swap calldata")
+    p.add_argument("--from-chain", required=True)
+    p.add_argument("--from-contract", required=True)
+    p.add_argument("--to-chain")
+    p.add_argument("--to-contract", required=True)
+    p.add_argument("--amount", required=True)
+    p.add_argument("--from-address", required=True)
+    p.add_argument("--to-address", required=True)
+    p.add_argument("--market", required=True)
+    p.add_argument("--from-symbol")
+    p.add_argument("--to-symbol")
+    p.add_argument("--slippage", type=float)
+    p.set_defaults(func=cmd_swap_calldata)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add /bgw-pro/swapx/pro/send support.

Completes the full swap flow: quote → calldata → sign → send.

MEV-protected transaction broadcasting, supports batch up to 100 txs.

Ref: https://web3.bitget.com/en/docs/swap/#mev-batch-send