### PR TITLE
docs: clarify swap amounts are human-readable, not raw units

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ An AI Agent skill that wraps the [Bitget Wallet ToB API](https://web3.bitget.com
 | **Batch Tx Info** | Batch transaction statistics for multiple tokens | "Compare volume for SOL and ETH" |
 | **Historical Coins** | Discover new tokens by timestamp | "What tokens launched today?" |
 | **Swap Send** | Broadcast signed transactions with MEV protection | "Broadcast my signed swap" |
+
+> ⚠️ **Swap amounts are human-readable** — pass `0.1` for 0.1 USDT, NOT `100000000000000000`. The `toAmount` in responses is also human-readable. This differs from most on-chain APIs.
 | **Swap Quote** | Best-route quote for cross-chain/same-chain swaps | "How much USDC for 1 SOL?" |
 | **Swap Calldata** | Generate unsigned transaction data | Execute trades via wallet signing |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,6 +13,19 @@ description: "Interact with Bitget Wallet ToB API for crypto market data, token 
 - **Credentials**: Built-in public demo credentials (works out of the box). Override with `BGW_API_KEY` / `BGW_API_SECRET` env vars for your own keys.
 - **Partner-Code**: `bgw_swap_public` (for swap endpoints)
 
+## ⚠️ IMPORTANT: Swap Amount Format
+
+**Swap endpoints (`swap-quote`, `swap-calldata`, `swap-send`) use HUMAN-READABLE amounts, NOT raw/smallest-unit values.**
+
+| ✅ Correct | ❌ Wrong |
+|-----------|---------|
+| `--amount 0.1` (0.1 USDT) | `--amount 100000000000000000` (this = 100 quadrillion USDT!) |
+| `--amount 1` (1 SOL) | `--amount 1000000000` (this = 1 billion SOL!) |
+
+The `toAmount` in responses is also human-readable. This differs from most on-chain APIs which use smallest units (wei, lamports, etc.).
+
+**Market/token endpoints** (`token-info`, `kline`, etc.) are not affected — they don't take amount inputs.
+
 ## Scripts
 
 All scripts are in `scripts/` and use Python 3.11+. No external credential setup needed — demo API keys are built in.

--- a/scripts/bitget_api.py
+++ b/scripts/bitget_api.py
@@ -284,7 +284,8 @@ def main():
     p.add_argument("--from-contract", required=True)
     p.add_argument("--to-chain")
     p.add_argument("--to-contract", required=True)
-    p.add_argument("--amount", required=True)
+    p.add_argument("--amount", required=True,
+                   help="Human-readable amount (e.g. 0.1 = 0.1 USDT, NOT wei/lamports)")
     p.add_argument("--from-symbol")
     p.add_argument("--to-symbol")
     p.add_argument("--from-address")
@@ -296,7 +297,8 @@ def main():
     p.add_argument("--from-contract", required=True)
     p.add_argument("--to-chain")
     p.add_argument("--to-contract", required=True)
-    p.add_argument("--amount", required=True)
+    p.add_argument("--amount", required=True,
+                   help="Human-readable amount (e.g. 0.1 = 0.1 USDT, NOT wei/lamports)")
     p.add_argument("--from-address", required=True)
     p.add_argument("--to-address", required=True)
     p.add_argument("--market", required=True)


### PR DESCRIPTION
## Problem
Swap API `fromAmount` uses human-readable values (e.g. `0.1` for 0.1 USDT), NOT smallest chain units (wei/lamports). This is opposite to most on-chain API conventions.

AI agents (including ourselves) passed `100000000000000000` thinking it was 0.1 USDT, but the API interpreted it as 100 quadrillion USDT, causing `estimateRevert=true` and failed transactions.

## Fix
- Add prominent warnings in SKILL.md, README, CLI help text, and MCP tool docstrings
- Correct examples throughout documentation

## Verified
✅ Tested with `fromAmount=0.1` — successful swap 0.1 USDT → 0.1005 USDC on BNB Chain
https://bscscan.com/tx/0ecd1dbea9bd8928c366745d674142535f0c502cf2d801dd910f149bc09899e2