### PR TITLE
docs: rename to Bitget Wallet Trade Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Bitget Wallet ToB API Skill
+# Bitget Wallet Trade Skill
 
 ## Overview
 
-An AI Agent skill that wraps the [Bitget Wallet ToB API](https://web3.bitget.com/en/docs), enabling natural-language-driven on-chain data queries and swap operations.
+An AI Agent skill that wraps the [Bitget Wallet API](https://web3.bitget.com/en/docs), enabling natural-language-driven on-chain data queries and swap operations.
 
 ### Core Capabilities
 
@@ -40,7 +40,7 @@ bitget_api.py (Python 3.11+)
     ↓  ← Built-in demo keys or env var override
 HMAC-SHA256 Signing
     ↓
-Bitget Wallet ToB API (bopenapi.bgwapi.io)
+Bitget Wallet API (bopenapi.bgwapi.io)
     ↓
 Structured JSON → Agent interprets → Natural language response
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: bitget-wallet
-description: "Interact with Bitget Wallet ToB API for crypto market data, token info, swap quotes, and security audits. Use when the user asks about token prices, market data, swap/trading quotes, token security checks, K-line charts, or token rankings on supported chains (ETH, SOL, BSC, Base, etc.)."
+description: "Interact with Bitget Wallet API for crypto market data, token info, swap quotes, and security audits. Use when the user asks about token prices, market data, swap/trading quotes, token security checks, K-line charts, or token rankings on supported chains (ETH, SOL, BSC, Base, etc.)."
 ---
 
-# Bitget Wallet ToB API
+# Bitget Wallet Trade Skill
 
 ## API Overview
 


### PR DESCRIPTION
Rename from "Bitget Wallet ToB API Skill" to "Bitget Wallet Trade Skill".

- Updated SKILL.md title and description
- Updated README.md title and references
- Removed all "ToB" references (internal API naming not relevant to users)