### PR TITLE
docs: rename to Bitget Wallet Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bitget Wallet Trade Skill
+# Bitget Wallet Skill
 
 ## Overview
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: bitget-wallet
 description: "Interact with Bitget Wallet API for crypto market data, token info, swap quotes, and security audits. Use when the user asks about token prices, market data, swap/trading quotes, token security checks, K-line charts, or token rankings on supported chains (ETH, SOL, BSC, Base, etc.)."
 ---
 
-# Bitget Wallet Trade Skill
+# Bitget Wallet Skill
 
 ## API Overview
 


### PR DESCRIPTION
Rename from "Bitget Wallet ToB API" to "Bitget Wallet Skill".

- Updated SKILL.md title and description
- Updated README.md title and references
- Removed "ToB" from skill-facing names (API address unchanged)