### PR TITLE
fix: Solana gasless IS supported (min ~$5-6 threshold)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format: date-based versioning (`YYYY.M.DD`). Each release includes a sequential 
 
 ---
 
+## [2026.3.9-1] - 2026-03-09
+
+### Fixed
+- **Solana gasless IS supported** — corrected previous conclusion that Solana didn't support gasless
+  - Gasless has a **minimum amount threshold (~$5-6 USD)** — below threshold, `features: []`; above, `features: ["no_gas"]`
+  - Same-chain gasless verified: 6 USDC → 5.76 USDT ✅
+  - Cross-chain gasless verified: 20 USDC (Sol) → 19.87 USDC (Base) ✅
+  - Updated all docs: trading.md, wallet-signing.md, README.md
+
+### Tested
+- Solana same-chain gasless (order `6e31ea59`) — pure Python Ed25519 signing ✅
+- Sol→Base cross-chain gasless (order `d106d921`) — 20 USDC, ~20s completion ✅
+- Pure Python signing (zero external deps) works flawlessly for gasless 2-signer transactions
+
 ## [2026.3.6-3] - 2026-03-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ python3 scripts/bitget_api.py swap-quote \
 | Arbitrum | ✅ | ✅ | ✅ |
 | Polygon | ✅ | ✅ | ✅ |
 | Morph | ✅ | ✅ | ✅ |
-| Solana | ✅ | ⚠️ Pending | ❌ Not supported |
+| Solana | ✅ | ✅ | ✅ (min ~$5-6 USD) |
 
 > Calldata mode (non-order) supports additional chains: Tron, TON, Sui, Optimism, and more.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bitget-wallet
-version: "2026.3.6-3"
+version: "2026.3.9-1"
 updated: "2026-03-06"
 description: "Interact with Bitget Wallet API for crypto market data, token info, swap quotes, and security audits. Use when the user asks about token prices, market data, swap/trading quotes, token security checks, K-line charts, or token rankings on supported chains (ETH, SOL, BSC, Base, etc.)."
 ---

--- a/docs/trading.md
+++ b/docs/trading.md
@@ -183,7 +183,7 @@ else:
 ```
 
 **⚠️ Important: `features` in order-quote is not always reliable.**
-In testing, some routes return `features: []` in the quote but still accept `--feature no_gas` in order-create. When the wallet has zero native token balance, always try `no_gas` regardless of the quote's `features` field. If order-create rejects it, fall back to informing the user they need gas.
+Some routes have a minimum amount threshold for gasless support. For example, Solana gasless requires ~$5-6 USD minimum — below this, `features: []` is returned. Always check the `features` field from `order-quote` before using `--feature no_gas`. If `features` is empty and the wallet has zero native token balance, inform the user they need to either increase the amount or acquire native tokens for gas.
 
 ### Order Create Response: Two Modes
 
@@ -379,7 +379,7 @@ When a cross-chain order fails after the source transaction is already on-chain,
 
 1. **Cross-chain minimum amount**: Varies by chain. EVM chains: ~$1-5. Solana: $10 minimum (liqBridge only, no CCTP). Morph: $5 minimum. Below minimum returns `80002 amount too low`.
 
-2. **`no_gas` requires quote support**: Only use `--feature no_gas` when `order-quote` returns `"no_gas"` in the `features` array. The API may accept the flag at create time without validation, but the backend will fail to execute. Solana currently does NOT support `no_gas` (features always `[]`).
+2. **`no_gas` requires quote support**: Only use `--feature no_gas` when `order-quote` returns `"no_gas"` in the `features` array. The API may accept the flag at create time without validation, but the backend will fail to execute. Solana supports `no_gas` above a minimum amount threshold (~$5-6 USD); below that, `features` returns `[]`.
 
 3. **Base same-chain without no_gas**: `order-create` on Base without `--feature no_gas` returns `80000 system error` when the wallet has no ETH. This is because the API can't construct a normal tx for an account with no gas. Solution: use `no_gas`.
 
@@ -440,7 +440,7 @@ When a cross-chain order fails after the source transaction is already on-chain,
 | Chain | Code | Same-chain | Cross-chain |
 |-------|------|-----------|-------------|
 | Ethereum | `eth` | ✅ | ✅ |
-| Solana | `sol` | ✅ | ✅ (EVM→Sol ✅; Sol→EVM requires SOL for gas) |
+| Solana | `sol` | ✅ | ✅ (Gasless supported above ~$5-6 min; both same-chain and cross-chain) |
 | BNB Chain | `bnb` | ✅ | ✅ |
 | Base | `base` | ✅ | ✅ |
 | Arbitrum | `arbitrum` | ✅ | ✅ |
@@ -571,11 +571,11 @@ The order is a contract — the user sees the actual order details, confirms, TH
 | Polygon | ✅ Supported | Same-chain confirmed; cross-chain requires 7702 binding first |
 | Arbitrum | ✅ Supported | — |
 | Morph | ✅ Supported | — |
-| Solana | ❌ Not supported | Solana as source chain: `no_gas` not available (quote returns `features: []`). EVM→Sol cross-chain works with gasless on the EVM source chain. |
+| Solana | ✅ Supported (min amount) | Solana gasless has a **minimum amount threshold** (~$5-6 USD). Below threshold, quote returns `features: []`. Above threshold, returns `features: ["no_gas"]`. Both same-chain and cross-chain (Sol→EVM) gasless work. |
 
 **⚠️ Cross-chain gasless requires source chain 7702 binding.** If the wallet has never done a gasless transaction on the source chain, the first cross-chain order will fall back to normal txs. Do a same-chain gasless swap first to bind 7702, then cross-chain gasless will work.
 
-**Only use gasless when `order-quote` returns `"no_gas"` in `features`.** Do not blindly try — the API accepts the flag but backend execution will fail if unsupported.
+**Only use gasless when `order-quote` returns `"no_gas"` in `features`.** Do not blindly try — the API accepts the flag but backend execution will fail if unsupported. Some chains (e.g., Solana) have a minimum amount threshold for gasless; if the amount is too small, try increasing it.
 
 **User override:** If the user explicitly says to use their own gas (e.g., "use my gas", "user gas", "不要 gasless", "用自己的 gas"), do NOT pass `--feature no_gas` to order-create. The order will use normal gas mode instead, and gas is paid from the wallet's native token balance. Show "Gas mode: User Gas (native token)" in the confirmation summary.
 

--- a/docs/wallet-signing.md
+++ b/docs/wallet-signing.md
@@ -145,7 +145,7 @@ The first N account keys in the message correspond to required signers (N = `hea
 | **Gasless (no_gas)** | Relayer (fee payer) | User wallet | Backend fills sig[0] after submission |
 | **User gas** | User wallet | — | User is the sole signer and fee payer |
 
-**⚠️ Solana gasless status (2026-03-06):** Backend does NOT currently support Solana gasless. `features: []` returned for all Solana quotes. Forcing `no_gas` creates the order but relayer never signs `sig[0]` → order fails immediately. Use `user_gas` mode only.
+**Solana gasless status (2026-03-09 updated):** Solana gasless IS supported, but has a **minimum amount threshold (~$5-6 USD)**. Below this threshold, `order-quote` returns `features: []`. Above it, `features: ["no_gas"]` is returned and gasless works correctly — relayer signs `sig[0]`, user partial-signs `sig[1]`. Both same-chain swaps and cross-chain (Sol→EVM) gasless are verified working.
 
 ### Partial Signing Pattern
 


### PR DESCRIPTION
## Summary

Corrected previous conclusion that Solana didn't support gasless. Testing confirmed it works above a minimum amount threshold (~$5-6 USD).

## Verified
- Same-chain gasless: 6 USDC → 5.76 USDT ✅ (order `6e31ea59`)
- Cross-chain gasless: 20 USDC Sol→Base → 19.87 USDC ✅ (order `d106d921`)
- Pure Python Ed25519 signing, zero external deps

## Changes
- `docs/trading.md` — Updated gasless support table, removed "Sol not supported" statements, added min threshold info
- `docs/wallet-signing.md` — Updated Solana gasless status note
- `README.md` — Solana gasless column: ❌ → ✅ (min ~$5-6)
- `CHANGELOG.md` — v2026.3.9-1
- `SKILL.md` — version bump