### PR TITLE
refactor: unify noGas terminology to gasless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,8 @@ Format: date-based versioning (`YYYY.M.DD`). Each release includes a sequential 
 - Market field in order confirmation summary (e.g., `bgwAggregator`, `bkbridgev3.liqbridge`)
 
 ### Fixed
-- Solana gasless status: changed from "❌ Not working (bug)" to "❌ Not supported" — `no_gas` is not available on Solana (quote returns `features: []`)
-- Gasless rule: only use `no_gas` when quote returns it in `features` array (API accepts flag without validation but execution fails)
+- Solana gasless status: changed from "❌ Not working (bug)" to "❌ Not supported" — gasless is not available on Solana (quote returns `features: []`)
+- Gasless rule: only use gasless when quote returns `"no_gas"` in `features` array (API accepts flag without validation but execution fails)
 - Cross-chain minimum amounts: Solana $10, Morph $5 (previously documented as ~$2 for all)
 
 ---
@@ -92,7 +92,7 @@ Format: date-based versioning (`YYYY.M.DD`). Each release includes a sequential 
   - `order-submit` — submit signed transactions
   - `order-status` — query order lifecycle status
 - **Cross-chain swaps**: swap tokens between different chains in one order (e.g., USDC on Base → USDT on Polygon)
-- **Gasless mode (no_gas)**: pay gas with input token, no native token needed (EVM only)
+- **Gasless mode**: pay gas with input token, no native token needed (EVM only)
 - **EIP-7702 support**: EIP-712 typed data signing for gasless execution
 - **Order status tracking**: full lifecycle (init → processing → success/failed/refunding/refunded)
 - **B2B fee splitting**: `feeRate` parameter for partner commission

--- a/SKILL.md
+++ b/SKILL.md
@@ -243,7 +243,7 @@ python3 scripts/bitget_api.py order-quote \
   --to-chain bnb --to-contract 0x55d398326f99059fF775485246999027B3197955 \
   --amount 2.0 --from-address <wallet>
 
-# Order create (returns unsigned tx data; use --feature no_gas for gasless)
+# Order create (returns unsigned tx data; use --feature no_gas for gasless mode)
 python3 scripts/bitget_api.py order-create \
   --from-chain base --from-contract 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
   --to-chain bnb --to-contract 0x55d398326f99059fF775485246999027B3197955 \

--- a/docs/trading.md
+++ b/docs/trading.md
@@ -24,7 +24,7 @@ Before executing any swap, the agent should silently run risk checks and present
 **Order Mode flow (default):**
 
 ```
-4. order-quote  → Get price, market, check no_gas support
+4. order-quote  → Get price, market, check gasless support
 5. order-create → Create order (returns unsigned data)
 6. order-status → Get accurate toAmount
 7. PRESENT      → Show confirmation (MANDATORY, wait for user)
@@ -57,7 +57,7 @@ On EVM chains (Ethereum, BNB Chain, Base, Arbitrum, Optimism), tokens require an
 - USDT on some chains (notably Ethereum mainnet) requires setting allowance to 0 before setting a new value.
 - **Native tokens** (ETH, SOL, BNB) do not need approval — only ERC-20/SPL tokens.
 - Approval is a one-time cost per token per router. Once approved with max amount, subsequent swaps of the same token skip this step.
-- **Order Mode gasless**: When using Order Mode with `no_gas`, approval is **automatically bundled** into the gasless transaction — the agent does NOT need to handle approval separately. The backend includes the approve call in the EIP-7702 delegated execution.
+- **Order Mode gasless**: When using Order Mode with gasless, approval is **automatically bundled** into the gasless transaction — the agent does NOT need to handle approval separately. The backend includes the approve call in the EIP-7702 delegated execution.
 - **Solana does not use approvals** — this applies only to EVM chains.
 
 Include the approval status in the confirmation summary when relevant:
@@ -119,7 +119,7 @@ Transaction costs vary by chain. Be aware of these when presenting swap quotes:
 The Order Mode API (`order-*` commands) is the **recommended** way to execute swaps. It supports everything the legacy `swap-*` flow does, plus:
 
 - **Cross-chain swaps** — swap tokens between different chains in one order (e.g., USDC on Base → USDT on BNB Chain)
-- **Gasless transactions (no_gas)** — pay gas fees using the input token instead of requiring native tokens
+- **Gasless transactions** — pay gas fees using the input token instead of requiring native tokens
 - **Order tracking** — full order lifecycle with status updates, refund handling
 - **EIP-7702 support** — advanced signature mode for gasless execution
 - **B2B fee splitting** — partners can set custom fee rates (`feeRate`)
@@ -129,14 +129,14 @@ The Order Mode API (`order-*` commands) is the **recommended** way to execute sw
 | Scenario | Use |
 |----------|-----|
 | Cross-chain swap | Order Mode (only option) |
-| No native token for gas | Order Mode with `no_gas` |
+| No native token for gas | Order Mode with gasless |
 | Same-chain swap | Either (Order Mode recommended) |
 | Need order tracking/refunds | Order Mode |
 
 ### Order Flow: 4-Step Process
 
 ```
-1. order-quote   → Get price, recommended market, check no_gas support
+1. order-quote   → Get price, recommended market, check gasless support
 2. order-create  → Create order, receive unsigned tx/signature data
 3. (wallet signs the transaction or EIP-712 typed data)
 4. order-submit  → Submit signed tx, get orderId confirmation
@@ -159,7 +159,7 @@ Key fields to check:
 | `features: ["no_gas"]` | If present, gasless mode is available |
 | `eip7702Bindend` | Whether address has EIP-7702 binding |
 
-### Gasless Mode (no_gas)
+### Gasless Mode
 
 Gasless mode uses EIP-7702 delegation — a backend relayer constructs and pays for the transaction on your behalf. The gas cost is deducted from the input token amount.
 
@@ -172,14 +172,14 @@ Gasless mode uses EIP-7702 delegation — a backend relayer constructs and pays 
 
 **Auto-detection logic:**
 ```
-Default: always use no_gas when available.
+Default: always use gasless when available.
 
 if order-quote returns features: ["no_gas"]:
     auto-apply --feature no_gas to order-create
 elif user has no native token for gas:
     warn: "Insufficient gas. This route does not support gasless mode."
 else:
-    proceed without no_gas (normal tx mode)
+    proceed without gasless (normal tx mode)
 ```
 
 **⚠️ Important: `features` in order-quote is not always reliable.**
@@ -382,9 +382,9 @@ When a cross-chain order fails after the source transaction is already on-chain,
 
 1. **Cross-chain minimum amount**: Varies by chain. EVM chains: ~$1-5. Solana: $10 minimum (liqBridge only, no CCTP). Morph: $5 minimum. Below minimum returns `80002 amount too low`.
 
-2. **`no_gas` requires quote support**: Only use `--feature no_gas` when `order-quote` returns `"no_gas"` in the `features` array. The API may accept the flag at create time without validation, but the backend will fail to execute. Solana supports `no_gas` above a minimum amount threshold (~$5-6 USD); below that, `features` returns `[]`.
+2. **Gasless requires quote support**: Only use `--feature no_gas` when `order-quote` returns `"no_gas"` in the `features` array. The API may accept the flag at create time without validation, but the backend will fail to execute. Solana supports gasless above a minimum amount threshold (~$5-6 USD); below that, `features` returns `[]`.
 
-3. **Base same-chain without no_gas**: `order-create` on Base without `--feature no_gas` returns `80000 system error` when the wallet has no ETH. This is because the API can't construct a normal tx for an account with no gas. Solution: use `no_gas`.
+3. **Base same-chain without gasless**: `order-create` on Base without `--feature no_gas` returns `80000 system error` when the wallet has no ETH. This is because the API can't construct a normal tx for an account with no gas. Solution: use gasless (`--feature no_gas`).
 
 4. **EIP-712 hash mismatch**: Do NOT use `encode_typed_data` from eth-account or similar libraries. Their encoding of nested `Call[]` with `bytes callData` differs from the API/contract implementation. Always sign the API-provided `hash` directly.
 
@@ -470,8 +470,8 @@ The order is a contract — the user sees the actual order details, confirms, TH
 
 ```
 1. security       → Check token safety (automatic, silent unless issues found)
-2. order-quote    → Get price, market, check no_gas + eip7702Bindend
-3. order-create   → Create order (auto-apply no_gas if available)
+2. order-quote    → Get price, market, check gasless + eip7702Bindend
+3. order-create   → Create order (auto-apply gasless if available)
                      Returns orderId + unsigned tx/signature data
 4. order-status   → Get order details (toAmount is more accurate than quote)
 5. PRESENT        → Show confirmation summary to user (MANDATORY)
@@ -548,7 +548,7 @@ The order is a contract — the user sees the actual order details, confirms, TH
 **Gas mode strategy: ALWAYS try gasless first.**
 
 ```
-1. Always pass --feature no_gas to order-create (regardless of quote features field)
+1. Always pass --feature no_gas to order-create (always try gasless first)
 2. Check response:
    a. Returns `signatures` array → Gasless ✅ proceed with EIP-712 signing
    b. Returns `txs` array (normal transactions) → Gasless NOT supported on this chain
@@ -561,8 +561,8 @@ The order is a contract — the user sees the actual order details, confirms, TH
 **Why always try gasless:**
 - The `features` field in `order-quote` is unreliable (often returns `[]` even when gasless works)
 - The `eip7702Bindend` / `eip7702Contract` fields are more reliable but still not definitive
-- The only sure way to know: pass `no_gas` and check if response has `signatures` or `txs`
-- Cost of trying: zero (order-create with no_gas that falls back to txs is not an error)
+- The only sure way to know: pass `--feature no_gas` and check if response has `signatures` or `txs`
+- Cost of trying: zero (order-create with gasless that falls back to txs is not an error)
 
 **Gasless support by chain (as of 2026-03-04):**
 
@@ -592,7 +592,7 @@ The order is a contract — the user sees the actual order details, confirms, TH
 
 **Always use `order-status.toAmount` for the confirmation summary**, not the quote's toAmount. The order-status value is calculated after actual routing and is more accurate.
 
-- When using `no_gas` mode, gas is still deducted from the input. Even the order-status `toAmount` may not fully reflect gas deduction.
+- When using gasless mode, gas is still deducted from the input. Even the order-status `toAmount` may not fully reflect gas deduction.
 - The **actual received amount** is only known after completion via `receiveAmount`.
 - Always present `toAmount` as an estimate: use "~" prefix (e.g., "~1.94 USDT").
 

--- a/docs/wallet-signing.md
+++ b/docs/wallet-signing.md
@@ -142,7 +142,7 @@ The first N account keys in the message correspond to required signers (N = `hea
 
 | Mode | sig[0] | sig[1] | Description |
 |------|--------|--------|-------------|
-| **Gasless (no_gas)** | Relayer (fee payer) | User wallet | Backend fills sig[0] after submission |
+| **Gasless** | Relayer (fee payer) | User wallet | Backend fills sig[0] after submission |
 | **User gas** | User wallet | — | User is the sole signer and fee payer |
 
 **Solana gasless status (2026-03-09 updated):** Solana gasless IS supported, but has a **minimum amount threshold (~$5-6 USD)**. Below this threshold, `order-quote` returns `features: []`. Above it, `features: ["no_gas"]` is returned and gasless works correctly — relayer signs `sig[0]`, user partial-signs `sig[1]`. Both same-chain swaps and cross-chain (Sol→EVM) gasless are verified working.

--- a/scripts/bitget_api.py
+++ b/scripts/bitget_api.py
@@ -204,7 +204,7 @@ def cmd_swap_calldata(args):
 
 
 def cmd_order_quote(args):
-    """Get order-mode swap price (supports cross-chain + no_gas)."""
+    """Get order-mode swap price (supports cross-chain + gasless)."""
     body = {
         "fromChain": args.from_chain,
         "fromContract": args.from_contract,
@@ -384,7 +384,7 @@ def main():
     p.add_argument("--txs", nargs="+", required=True, help="Transactions as id:chain:from:rawTx")
     p.set_defaults(func=cmd_swap_send)
 
-    # order-quote (order mode - cross-chain + no_gas support)
+    # order-quote (order mode - cross-chain + gasless support)
     p = sub.add_parser("order-quote", help="Get order-mode swap price (cross-chain + gasless)")
     p.add_argument("--from-chain", required=True, help="Source chain (e.g. base, bnb, eth)")
     p.add_argument("--from-contract", required=True, help="Source token contract (empty for native)")
@@ -408,7 +408,7 @@ def main():
     p.add_argument("--market", required=True, help="Market from order-quote response")
     p.add_argument("--slippage", type=float, help="Slippage tolerance (e.g. 3.0 = 3%%)")
     p.add_argument("--fee-rate", help="Partner fee percentage")
-    p.add_argument("--feature", help="Gas feature: 'no_gas' to pay gas with input token")
+    p.add_argument("--feature", help="Gasless feature: pass 'no_gas' to pay gas with input token")
     p.set_defaults(func=cmd_order_create)
 
     # order-submit


### PR DESCRIPTION
## Changes

Replace all `noGas` / standalone `no_gas` concept references with `gasless` for consistent terminology.

**What changed:**
- Doc headings: `Gasless Mode (no_gas)` → `Gasless Mode`
- Concept text: `no_gas support` → `gasless support`
- Code comments: `cross-chain + no_gas` → `cross-chain + gasless`
- CHANGELOG entries: `Gasless mode (no_gas)` → `Gasless mode`

**What stays unchanged:**
- API parameter values: `--feature no_gas`
- API response values: `features: ["no_gas"]`
- Literal string comparisons in code

**Files:** CHANGELOG.md, SKILL.md, docs/trading.md, docs/wallet-signing.md, scripts/bitget_api.py (5 files, 24 insertions, 24 deletions)