### PR TITLE
docs: enforce strict swap.md flow compliance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,6 +26,16 @@ description: "Interact with Bitget Wallet API for crypto market data, token info
    python3 scripts/bitget_agent_api.py check-swap-token --from-chain ... --from-contract ... --from-symbol ... --to-chain ... --to-contract ... --to-symbol ...
    ```
 
+**Swap execution must strictly follow `docs/swap.md` Flow Overview — no shortcuts:**
+
+1. **Balance check** — verify fromToken + native token balance before anything else
+2. **Token risk check** — check-swap-token for both fromToken and toToken
+3. **Quote** — display **all** market results to user, recommend the first, let user choose
+4. **Confirm** — must display three fields to user: `outAmount` (expected), `minAmount` (minimum), `gasTotalAmount` (gas cost); check `recommendFeatures` for gas sufficiency
+5. **User confirmation** — **do not** sign or send until user explicitly confirms ("confirm", "execute", "yes")
+6. **makeOrder + sign + send** — execute as one atomic operation (use `order_make_sign_send.py`)
+7. **Query status** — check order result; ignore `tips` when status=success
+
 See Scripts for full command details and `docs/swap.md` for the complete flow.
 
 **Technical reference (no need to read .py files):**


### PR DESCRIPTION
## Changes

在 SKILL.md 中新增强制性 7 步 swap 流程清单，要求 Agent 严格遵守 `docs/swap.md` Flow Overview，不允许跳步：

1. **余额检查** — 验证 fromToken + native token 余额
2. **代币风险检查** — check-swap-token 双向检查
3. **Quote** — 展示所有市场结果，推荐第一个，用户选择
4. **Confirm** — 必须展示 outAmount / minAmount / gasTotalAmount 三个字段
5. **用户确认** — 未经用户明确确认不得签名发送
6. **签名发送** — makeOrder + sign + send 原子操作
7. **状态查询** — success 时忽略 tips

### Files Changed
- `SKILL.md` — +10 lines (mandatory swap flow checklist)