### PR TITLE
security: remove legacy --private-key CLI arguments

### DIFF
--- a/scripts/order_make_sign_send.py
+++ b/scripts/order_make_sign_send.py
@@ -73,10 +73,6 @@ def main():
     parser.add_argument("--private-key-file", default=None, help="Path to file containing EVM private key (hex). File is read and deleted.")
     parser.add_argument("--private-key-file-sol", default=None, help="Path to file containing Solana private key (base58 or hex). File is read and deleted.")
     parser.add_argument("--private-key-file-tron", default=None, help="Path to file containing Tron private key (hex). File is read and deleted.")
-    # Legacy support (deprecated, will be removed)
-    parser.add_argument("--private-key", default=None, help=argparse.SUPPRESS)
-    parser.add_argument("--private-key-sol", default=None, help=argparse.SUPPRESS)
-    parser.add_argument("--private-key-tron", default=None, help=argparse.SUPPRESS)
     parser.add_argument("--from-address", required=True, help="Sender address")
     parser.add_argument("--to-address", required=True, help="Receiver address (usually same as from-address)")
     parser.add_argument("--order-id", required=True, help="From confirm response data.orderId")
@@ -92,15 +88,12 @@ def main():
     parser.add_argument("--protocol", required=True)
     args = parser.parse_args()
 
-    # Read keys from files (preferred) or legacy args
+    # Read keys from files — delete file immediately after reading
     from key_utils import read_key_file
 
-    if args.private_key_file:
-        args.private_key = read_key_file(args.private_key_file)
-    if args.private_key_file_sol:
-        args.private_key_sol = read_key_file(args.private_key_file_sol)
-    if args.private_key_file_tron:
-        args.private_key_tron = read_key_file(args.private_key_file_tron)
+    args.private_key = read_key_file(args.private_key_file) if args.private_key_file else None
+    args.private_key_sol = read_key_file(args.private_key_file_sol) if args.private_key_file_sol else None
+    args.private_key_tron = read_key_file(args.private_key_file_tron) if args.private_key_file_tron else None
 
     if not args.private_key and not args.private_key_sol and not args.private_key_tron:
         print("Error: must provide --private-key-file (EVM), --private-key-file-sol (Solana), or --private-key-file-tron (Tron)", file=sys.stderr)

--- a/scripts/order_sign.py
+++ b/scripts/order_sign.py
@@ -12,17 +12,17 @@ Signs order-create response for both EVM and Solana chains.
 - Solana txs mode: partial-sign VersionedTransaction (or Legacy fallback)
 
 Usage:
-    # EVM
-    python3 scripts/order_sign.py --order-json '<json>' --private-key <hex>
+    # EVM (key from file, file auto-deleted after reading)
+    python3 scripts/order_sign.py --order-json '<json>' --private-key-file /tmp/.pk
 
     # Tron (TRX)
-    python3 scripts/order_sign.py --order-json '<json>' --private-key-tron <hex>
+    python3 scripts/order_sign.py --order-json '<json>' --private-key-file-tron /tmp/.pk
 
     # Solana
-    python3 scripts/order_sign.py --order-json '<json>' --private-key-sol <base58|hex>
+    python3 scripts/order_sign.py --order-json '<json>' --private-key-file-sol /tmp/.pk
 
     # Pipe from order-create
-    python3 scripts/bitget_agent_api.py order-create ... | python3 scripts/order_sign.py --private-key <hex>
+    python3 scripts/bitget_agent_api.py order-create ... | python3 scripts/order_sign.py --private-key-file /tmp/.pk
 
 Output: JSON array of signed strings, ready for order-submit --signed-txs
 
@@ -746,21 +746,23 @@ def main():
     parser.add_argument("--private-key-file", help="Path to file containing EVM private key (hex). File is read and deleted.")
     parser.add_argument("--private-key-file-sol", help="Path to file containing Solana private key. File is read and deleted.")
     parser.add_argument("--private-key-file-tron", help="Path to file containing Tron private key. File is read and deleted.")
-    # Legacy support (deprecated, will be removed)
-    parser.add_argument("--private-key", help=argparse.SUPPRESS)
-    parser.add_argument("--private-key-sol", help=argparse.SUPPRESS)
-    parser.add_argument("--private-key-tron", help=argparse.SUPPRESS)
     args = parser.parse_args()
 
-    # Read keys from files (preferred) — delete file immediately after reading
+    # Read keys from files — delete file immediately after reading
     from key_utils import read_key_file
 
     if args.private_key_file:
         args.private_key = read_key_file(args.private_key_file)
+    else:
+        args.private_key = None
     if args.private_key_file_sol:
         args.private_key_sol = read_key_file(args.private_key_file_sol)
+    else:
+        args.private_key_sol = None
     if args.private_key_file_tron:
         args.private_key_tron = read_key_file(args.private_key_file_tron)
+    else:
+        args.private_key_tron = None
 
     if args.order_json:
         response = json.loads(args.order_json)

--- a/scripts/x402_pay.py
+++ b/scripts/x402_pay.py
@@ -10,24 +10,21 @@ Handles HTTP 402 payment flows:
 Usage:
   # Sign an EIP-3009 payment from a 402 response
   python3 x402_pay.py sign-eip3009 \
-    --private-key <hex> \
+    --private-key-file /tmp/.pk \
     --token 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
     --chain-id 8453 \
     --to 0x209693Bc6afc0C5328bA36FaF03C514EF312287C \
-    --amount 10000 \
-    --token-name "USD Coin" \
-    --token-version "2" \
-    --max-timeout 60
+    --amount 10000
 
   # Sign a Solana partial transaction
   python3 x402_pay.py sign-solana \
-    --private-key <hex> \
+    --private-key-file /tmp/.pk \
     --transaction <base64-encoded-tx>
 
   # Full HTTP 402 flow (fetch + pay + retry)
   python3 x402_pay.py pay \
     --url https://api.example.com/premium \
-    --private-key <hex> \
+    --private-key-file /tmp/.pk \
     --chain-id 8453
 """
 
@@ -329,8 +326,6 @@ def main():
     p = sub.add_parser("sign-eip3009", help="Sign EIP-3009 transferWithAuthorization")
     p.add_argument("--private-key-file", default=None,
                    help="Path to file containing hex private key (read and deleted)")
-    p.add_argument("--private-key", default=os.environ.get("X402_PRIVATE_KEY"),
-                   help=argparse.SUPPRESS)  # deprecated
     p.add_argument("--token", required=True, help="Token contract address")
     p.add_argument("--chain-id", type=int, required=True, help="EVM chain ID")
     p.add_argument("--to", required=True, help="Payment recipient (payTo)")
@@ -344,8 +339,6 @@ def main():
     p = sub.add_parser("sign-solana", help="Partially sign Solana x402 transaction")
     p.add_argument("--private-key-file", default=None,
                    help="Path to file containing hex private key (read and deleted)")
-    p.add_argument("--private-key", default=os.environ.get("X402_PRIVATE_KEY"),
-                   help=argparse.SUPPRESS)  # deprecated
     p.add_argument("--transaction", required=True, help="Base64-encoded serialized transaction")
     p.set_defaults(func=cmd_sign_solana)
 
@@ -354,8 +347,6 @@ def main():
     p.add_argument("--url", required=True, help="URL to access")
     p.add_argument("--private-key-file", default=None,
                    help="Path to file containing hex private key (read and deleted)")
-    p.add_argument("--private-key", default=os.environ.get("X402_PRIVATE_KEY"),
-                   help=argparse.SUPPRESS)  # deprecated
     p.add_argument("--chain-id", type=int, help="Preferred chain ID")
     p.add_argument("--method", default="GET", help="HTTP method (default: GET)")
     p.add_argument("--data", help="Request body (JSON string)")
@@ -368,11 +359,15 @@ def main():
     if not args.command:
         parser.print_help()
         sys.exit(1)
-    # Read key from file if provided
+    # Read key from file or env var
     if hasattr(args, "private_key_file") and args.private_key_file:
         from key_utils import read_key_file
         args.private_key = read_key_file(args.private_key_file)
-    if hasattr(args, "private_key") and not args.private_key:
+    elif os.environ.get("X402_PRIVATE_KEY"):
+        args.private_key = os.environ["X402_PRIVATE_KEY"]
+    else:
+        args.private_key = None
+    if not args.private_key:
         print("Error: --private-key-file required (or set X402_PRIVATE_KEY env var)")
         sys.exit(1)
     args.func(args)


### PR DESCRIPTION
## Problem

Legacy `--private-key`, `--private-key-sol`, `--private-key-tron` CLI arguments were kept as hidden (SUPPRESS) for backward compatibility in PR #33. However, they still accept plaintext private keys via command line, which are visible in `ps`, shell history, and `/proc`.

## Fix

Removed all 9 legacy plaintext key arguments across 3 scripts:

| Script | Removed |
|--------|---------|
| `order_sign.py` | `--private-key`, `--private-key-sol`, `--private-key-tron` |
| `order_make_sign_send.py` | `--private-key`, `--private-key-sol`, `--private-key-tron` |
| `x402_pay.py` | `--private-key` × 3 subcommands |

Only `--private-key-file` variants remain. Passing `--private-key` now returns `unrecognized arguments` error.

`x402_pay.py` still supports `X402_PRIVATE_KEY` env var as fallback (env vars are not visible in `ps`).

## Verified

- BNB swap (USDT→USDC) via `--private-key-file`: ✅ success
- `--private-key` rejected by argparse: ✅ confirmed
- Internal function signatures unchanged — only CLI entry points affected