### PR TITLE
security: harden social-wallet secret handling

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -96,6 +96,7 @@ If NOT_FOUND, guide user:
 1. Open Bitget Wallet APP (v9.39.0+) → Social Login
 2. Settings → Bitget Wallet Skill → Enable → Copy appid + appsecret
 3. Save to `<skill_dir>/.social-wallet-secret` as `{"appid":"...","appsecret":"..."}`
+4. Restrict permissions: `chmod 600 <skill_dir>/.social-wallet-secret`
 
 ### Commands
 

--- a/scripts/social-wallet.py
+++ b/scripts/social-wallet.py
@@ -127,8 +127,7 @@ def call_api(endpoint: str, param_dict: dict) -> dict | None:
             except json.JSONDecodeError:
                 print(decrypted)
         except Exception as e:
-            print(f"ERROR: Decryption failed: {e}", file=sys.stderr)
-            print(json.dumps(data, indent=2, ensure_ascii=False))
+            print(f"ERROR: Decryption failed: {e} [status={data.get('status','')}] [trace={data.get('trace','')}]", file=sys.stderr)
     else:
         print(json.dumps(data.get("data", data), indent=2, ensure_ascii=False))
 


### PR DESCRIPTION
## What

Two security improvements for Social Login Wallet:

### 1. chmod 600 for .social-wallet-secret (SKILL.md)
Added step 4 to the setup guide: `chmod 600 .social-wallet-secret` to restrict file permissions to owner-only read/write.

### 2. No raw response dump on decryption failure (social-wallet.py)
Previously, when AES-GCM decryption failed, the full API response (including encrypted payload) was printed to stdout. Now it only prints the error message, status code, and trace ID to stderr.

## Why

- Secret file with default permissions (644) is readable by other users on the same machine
- Dumping raw API responses on error could leak encrypted data to logs or chat surfaces