### PR TITLE
feat: Social Login Wallet one-shot makeOrder+sign+send

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -57,7 +57,7 @@ description: "Interact with Bitget Wallet API for crypto market data, token info
 3. **Quote** — display **all** market results to user, recommend the first, let user choose
 4. **Confirm** — must display three fields to user: `outAmount` (expected), `minAmount` (minimum), `gasTotalAmount` (gas cost); check `recommendFeatures` for gas sufficiency
 5. **User confirmation** — **do not** sign or send until user explicitly confirms ("confirm", "execute", "yes")
-6. **makeOrder + sign + send** — execute as one atomic operation (use `order_make_sign_send.py` for mnemonic/private-key wallets; **Social Login Wallet must use manual 3-step flow** — see `docs/social-wallet.md`)
+6. **makeOrder + sign + send** — execute as one atomic operation (use `order_make_sign_send.py` for mnemonic/private-key wallets; use `social_order_make_sign_send.py` for Social Login Wallets — see `docs/social-wallet.md`)
 7. **Query status** — check order result; ignore `tips` when status=success
 
 See Scripts for full command details and `docs/swap.md` for the complete flow.
@@ -278,7 +278,8 @@ Use empty string `""` for native token contract (ETH, SOL, BNB, etc.).
 | Script | Purpose | Key commands |
 |--------|---------|-------------|
 | `bitget-wallet-agent-api.py` | Unified API client | Balance, token find (launchpad-tokens/search-tokens-v3/rankings), token check (security/coin-dev/coin-market-info/kline/tx-info), swap flow (quote→confirm→make-order→send→get-order-details) |
-| `order_make_sign_send.py` | One-shot swap execution | makeOrder + sign + send in one run. `--private-key-file` (EVM) or `--private-key-file-sol` (Solana). Avoids 60s expiry. |
+| `order_make_sign_send.py` | One-shot swap execution (mnemonic/private-key) | makeOrder + sign + send in one run. `--private-key-file` (EVM) or `--private-key-file-sol` (Solana). Avoids 60s expiry. |
+| `social_order_make_sign_send.py` | One-shot swap execution (Social Login Wallet) | makeOrder + sign (TEE) + send in one run. `--wallet-id` required. No local private key needed. |
 | `order_sign.py` | Sign makeOrder data | Outputs JSON array of signatures. Supports raw tx, EVM gasPayMaster (eth_sign), EIP-712, Solana Ed25519, Solana gasPayMaster. |
 | `x402_pay.py` | x402 payment | EIP-3009 signing, Solana partial-sign, HTTP 402 pay flow |
 | `social-wallet.py` | Social Login Wallet | Sign transactions/messages via Bitget Wallet TEE (no local private key needed) |
@@ -306,6 +307,8 @@ python3 scripts/bitget-wallet-agent-api.py coin-dev --chain sol --contract <addr
 python3 scripts/bitget-wallet-agent-api.py quote --from-chain bnb --from-contract <addr> --from-symbol USDT --from-amount 5 --to-chain bnb --to-contract "" --to-symbol BNB --from-address <wallet> --to-address <wallet>
 python3 scripts/bitget-wallet-agent-api.py confirm ... --market <id> --protocol <proto> --slippage <val> --feature user_gas
 python3 scripts/order_make_sign_send.py --private-key-file /tmp/.pk_evm --order-id <id> --from-chain bnb ... --market ... --protocol ...
+# Social Login Wallet: one-shot swap (no private key needed)
+python3 scripts/social_order_make_sign_send.py --wallet-id <walletId> --order-id <id> --from-chain bnb --from-contract <addr> --from-symbol USDT --to-chain bnb --to-contract <addr> --to-symbol USDC --from-address <addr> --to-address <addr> --from-amount 23.35 --slippage 0.005 --market bgwevmaggregator --protocol bgwevmaggregator_v000
 python3 scripts/bitget-wallet-agent-api.py get-order-details --order-id <id>
 ```
 

--- a/docs/social-wallet.md
+++ b/docs/social-wallet.md
@@ -58,7 +58,22 @@ Read-only operations (`get_address`, `get_public_key`, `validate_address`, `batc
 
 ## Integration with Swap Flow
 
-**⚠️ `order_make_sign_send.py` is NOT compatible with Social Login Wallets.** That script requires a local private key file, but Social Login Wallets sign via TEE API — no local private key exists. For Social Login Wallet swaps, you **must** use the 3-step manual flow:
+**Recommended: Use `social_order_make_sign_send.py`** — combines makeOrder + sign (TEE) + send in one run, avoiding the 60s expiry issue. No local private key needed.
+
+```bash
+python3 scripts/social_order_make_sign_send.py \
+  --wallet-id <walletId> \
+  --order-id <from confirm> \
+  --from-chain bnb --from-contract 0x... --from-symbol USDT \
+  --to-chain bnb --to-contract 0x... --to-symbol USDC \
+  --from-address 0x... --to-address 0x... \
+  --from-amount 23.35 --slippage 0.005 \
+  --market bgwevmaggregator --protocol bgwevmaggregator_v000
+```
+
+Auto-detects signing mode: EVM gasPayMaster, EVM regular tx, Solana, Tron.
+
+**Alternative: Manual 3-step flow** (for debugging or custom flows):
 
 1. **makeOrder** → `bitget-wallet-agent-api.py make-order ...`
 2. **Sign** → `social-wallet.py core sign_message/sign_transaction` (per tx, based on mode detection)

--- a/docs/swap.md
+++ b/docs/swap.md
@@ -13,7 +13,8 @@ This document describes the **Swap flow**: use `scripts/bitget-wallet-agent-api.
 | 0 | `bitget-wallet-agent-api.py check-swap-token` | Check fromToken and toToken for risks **before** quote; if risks or forbidden-buy on toToken, prompt user or stop. |
 | 1 | `bitget-wallet-agent-api.py quote` | First quote; returns multiple markets in `data.quoteResults`. Agent shows **all** results, recommends the first; user may choose another for confirm. |
 | 2 | `bitget-wallet-agent-api.py confirm` | Second quote; use market/protocol/slippage from **chosen** quote result (default first); Get latest quoteResult and orderId. The agent should display the `data.quoteResult`. If the `data.tips` are not empty, agent should display and remind user |
-| 3+4+5 | **`order_make_sign_send.py`** (recommended) | makeOrder + sign + send in one run |
+| 3+4+5 | **`order_make_sign_send.py`** (mnemonic/private-key wallets) | makeOrder + sign + send in one run |
+| 3+4+5 | **`social_order_make_sign_send.py`** (Social Login Wallet) | makeOrder + sign (TEE) + send in one run |
 | 3′ | `bitget-wallet-agent-api.py make-order` | Create order; returns unsigned data.txs (~60s expiry) |
 | 4′ | `order_sign.py` + fill `txs[].sig` | Sign data.txs with private key (derived from mnemonic, discarded after) |
 | 5′ | `bitget-wallet-agent-api.py send` | Submit signed order (body: orderId + txs) |
@@ -113,11 +114,16 @@ Or with JSON stdin: `echo '{"list":[{"chain":"...","contract":"...","symbol":"..
 
 ### 3–5. makeOrder, sign, send (combined — recommended)
 
-> **⚠️ Social Login Wallet exception:** `order_make_sign_send.py` requires a local private key file and is **NOT compatible** with Social Login Wallets. If the user is using a Social Login Wallet, skip this section and use the **separate steps (3′–5′)** below with `social-wallet.py` for signing. See [`docs/social-wallet.md`](social-wallet.md) for the full Social Login signing flow.
+**For mnemonic/private-key wallets:**
 
 - **Script (EVM):** `python3 scripts/order_make_sign_send.py --private-key-file /tmp/.pk_evm --from-address <addr> --to-address <addr> --order-id <from_confirm> --from-chain ... --from-contract ... --from-symbol ... --to-chain ... --to-contract ... --to-symbol ... --from-amount ... --slippage ... --market ... --protocol ...`
 - **Script (Solana):** `python3 scripts/order_make_sign_send.py --private-key-file-sol /tmp/.pk_sol --from-address <sol_addr> --to-address <sol_addr> --order-id <from_confirm> --from-chain sol ...`
 - **Behavior:** Takes private key from secure storage, calls makeOrder, signs `data.txs`, fills `txs[].sig`, then sends. Auto-detects EVM vs Solana from makeOrder response. Never outputs private keys. Use this so the ~60s makeOrder expiry does not run out.
+
+**For Social Login Wallets:**
+
+- **Script:** `python3 scripts/social_order_make_sign_send.py --wallet-id <walletId> --order-id <from_confirm> --from-address <addr> --to-address <addr> --from-chain ... --from-contract ... --from-symbol ... --to-chain ... --to-contract ... --to-symbol ... --from-amount ... --slippage ... --market ... --protocol ...`
+- **Behavior:** Calls makeOrder, signs each tx via Bitget Wallet TEE API (no local private key), then sends. Auto-detects signing mode: EVM gasPayMaster (eth_sign hash), EVM regular tx, Solana, or Tron. Same ~60s window but signing is fast (single API call per tx).
 
 ### 3′–5′. makeOrder, sign, send (separate steps)
 
@@ -152,7 +158,7 @@ Recommended flow:
 5. confirm → use market/protocol/slippage from the chosen quote result (default first); get and show latest quoteResult(data.quoteResult), orderId(data.orderId) and gasFee(data.gasFee); also show tips(data.tips) if not empty
 6. PRESENT → show confirmation summary (required)
 7. WAIT → user explicitly confirms
-8. order_make_sign_send.py (recommended for mnemonic/private-key wallets) or make-order → sign → send (must complete within ~60s). **Social Login Wallet: must use make-order → social-wallet.py sign → send (see docs/social-wallet.md).**
+8. **Mnemonic/private-key wallets:** `order_make_sign_send.py`. **Social Login Wallet:** `social_order_make_sign_send.py --wallet-id <walletId>`. Both complete makeOrder+sign+send within ~60s.
 9. get-order-details → show final status and txId / explorer link
 ```
 
@@ -200,7 +206,7 @@ The swap API supports 7 chains. Use these chain codes in all swap commands:
 2. **Human-readable amounts:** In the swap flow, **fromAmount** (and toAmount, fromAmount in makeOrder, etc.) are always **human-readable** (e.g. `0.01` for 0.01 USDT, `1` for 1 token). Do **not** convert to smallest units (wei, lamports, or token decimals); pass the value as the user would say it (e.g. `--from-amount 0.01`).
 3. **Native token contract:** Use empty string `""` for toContract/fromContract when the token is native.
 4. **Do not submit twice:** One confirmation, one sign+send; duplicate submit can double-spend.
-5. **makeOrder data expiry:** Unsigned txs from makeOrder are valid ~60s; use **order_make_sign_send.py** or sign and send immediately after makeOrder to avoid expiry.
+5. **makeOrder data expiry:** Unsigned txs from makeOrder are valid ~60s; use **order_make_sign_send.py** (mnemonic wallets) or **social_order_make_sign_send.py** (Social Login Wallet) to avoid expiry.
 6. **Chain codes:** Use API chain codes (`bnb`, `sol`, `eth`), not aliases (`bsc`, `solana`).
 7. **Gasless signing:** EVM gasPayMaster returns `msgs[]` with `signType: "eth_sign"` — `order_sign.py` returns full msgs JSON struct (not raw tx). Solana gasPayMaster uses `source.serializedTransaction` for partial-sign. Both are auto-detected.
 8. **Cross-chain minimum:** Cross-chain swaps require minimum $10 USD value.

--- a/scripts/social-wallet.py
+++ b/scripts/social-wallet.py
@@ -85,6 +85,71 @@ def _error_exit(msg: str):
 
 # ── API Call ──────────────────────────────────────────────
 
+def call_api_return(endpoint: str, param_dict: dict) -> dict:
+    """Call API and return decrypted result as dict (importable, no stdout)."""
+    timestamp = str(int(time.time() * 1000))
+    nonce = secrets.token_hex(16)
+
+    param_json = json.dumps(param_dict, separators=(",", ":"), ensure_ascii=False)
+    param_encrypted = aes_gcm_encrypt(param_json)
+    param_sign = hmac_sha384(f"{param_encrypted}|{timestamp}|{nonce}|{APPID}")
+
+    body = {"param": param_encrypted, "paramSign": param_sign}
+    body_str = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
+
+    headers = {
+        "Content-Type": "application/json",
+        "channel": "toc_agent",
+        "brand": "toc_agent",
+        "clientversion": "10.0.0",
+        "language": "en",
+        "token": "toc_agent",
+        "X-SIGN": _gateway_sign(endpoint, body_str, timestamp),
+        "X-TIMESTAMP": timestamp,
+        "x-agent-appid": APPID,
+        "x-nonce": nonce,
+        "sig": param_sign,
+    }
+
+    resp = requests.post(f"{BASE_URL}{endpoint}", headers=headers, data=body_str, timeout=15)
+    data = resp.json()
+
+    status = data.get("status", -1)
+    if resp.status_code != 200 or status != 0:
+        msg = data.get("msg", "unknown")
+        raise RuntimeError(f"Social wallet API error [status={status}]: {msg}")
+
+    resp_data = data.get("data") if isinstance(data.get("data"), dict) else {}
+    result_encrypted = resp_data.get("result", "")
+
+    if result_encrypted:
+        decrypted = aes_gcm_decrypt(result_encrypted)
+        try:
+            return json.loads(decrypted)
+        except json.JSONDecodeError:
+            return {"result": decrypted}
+    else:
+        return data.get("data", data)
+
+
+def sign_message_return(chain: str, message: str) -> dict:
+    """Sign a message via Social Login Wallet TEE. Returns decrypted result dict."""
+    load_secret()
+    if not APPID or not APPSECRET:
+        raise RuntimeError(f"Missing credentials. Create {SECRET_FILE}")
+    param = json.dumps({"chain": chain, "message": message}, separators=(",", ":"), ensure_ascii=False)
+    return call_api_return(ENDPOINTS["core"], {"operation": "sign_message", "param": param})
+
+
+def sign_transaction_return(chain: str, tx_params: dict) -> dict:
+    """Sign a transaction via Social Login Wallet TEE. Returns decrypted result dict."""
+    load_secret()
+    if not APPID or not APPSECRET:
+        raise RuntimeError(f"Missing credentials. Create {SECRET_FILE}")
+    param = json.dumps(tx_params, separators=(",", ":"), ensure_ascii=False)
+    return call_api_return(ENDPOINTS["core"], {"operation": "sign_transaction", "param": param})
+
+
 def call_api(endpoint: str, param_dict: dict) -> dict | None:
     timestamp = str(int(time.time() * 1000))
     nonce = secrets.token_hex(16)

--- a/scripts/social_order_make_sign_send.py
+++ b/scripts/social_order_make_sign_send.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+One-shot: makeOrder → sign (Social Login Wallet TEE) → send.
+
+Social Login Wallet equivalent of order_make_sign_send.py.
+No local private key needed — signing is done via Bitget Wallet TEE API.
+
+Supports: EVM (gasPayMaster + regular tx), Solana, Tron.
+
+Example:
+  python3 scripts/social_order_make_sign_send.py \
+    --wallet-id <walletId> \
+    --order-id <from confirm> \
+    --from-chain bnb --from-contract 0x55d3... --from-symbol USDT \
+    --to-chain bnb --to-contract 0x8AC7... --to-symbol USDC \
+    --from-address 0x39C6... --to-address 0x39C6... \
+    --from-amount 23.35 --slippage 0.005 \
+    --market bgwevmaggregator --protocol bgwevmaggregator_v000
+"""
+
+import argparse
+import importlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+_SOLANA_CHAIN_ID = 501
+
+# Chain code → social-wallet chain param mapping
+_EVM_CHAIN_MAP = {
+    "eth": "eth",
+    "bnb": "evm_custom#bnb",
+    "base": "evm_custom#base",
+    "arbitrum": "evm_custom#arb",
+    "matic": "matic",
+    "morph": "evm_custom#morph",
+    "op": "evm_custom#op",
+}
+
+_EVM_CHAIN_ID_MAP = {
+    "eth": 1,
+    "bnb": 56,
+    "base": 8453,
+    "arbitrum": 42161,
+    "matic": 137,
+    "morph": 2818,
+    "op": 10,
+}
+
+
+def _get_social_chain(api_chain: str) -> str:
+    """Map API chain code to social-wallet chain param."""
+    c = api_chain.lower()
+    if c in _EVM_CHAIN_MAP:
+        return _EVM_CHAIN_MAP[c]
+    if c in ("sol", "solana"):
+        return "sol"
+    if c in ("trx", "tron"):
+        return "tron"
+    return c
+
+
+def _is_solana_order(order_data: dict) -> bool:
+    for tx_item in order_data.get("txs", []):
+        derive = tx_item.get("deriveTransaction") or {}
+        cid = tx_item.get("chainId") or derive.get("chainId")
+        if cid is not None and int(cid) == _SOLANA_CHAIN_ID:
+            return True
+        chain = (tx_item.get("chain") or "").lower()
+        if chain in ("sol", "solana"):
+            return True
+        if derive.get("serializedTransaction"):
+            return True
+        source = tx_item.get("source") or derive.get("source")
+        if isinstance(source, dict) and source.get("serializedTransaction"):
+            return True
+    return False
+
+
+def _is_tron_order(order_data: dict) -> bool:
+    for tx_item in order_data.get("txs", []):
+        chain = (tx_item.get("chain") or "").lower()
+        if chain in ("trx", "tron"):
+            return True
+        if tx_item.get("transaction") and isinstance(tx_item["transaction"].get("raw_data_hex"), str):
+            return True
+    return False
+
+
+def _sign_evm_gasPayMaster(tx_item: dict, social_chain: str, sw) -> str:
+    """Sign gasPayMaster msgs (eth_sign hashes) via Social Login Wallet.
+    Returns JSON string of msgs with sig fields filled."""
+    derive = tx_item.get("deriveTransaction", {})
+    msgs = derive.get("msgs") or tx_item.get("msgs") or []
+
+    for m in msgs:
+        h = m["hash"]
+        result = sw.sign_message_return(social_chain, f"EthSign:{h}")
+        m["sig"] = result.get("result", result.get("signature", ""))
+
+    # Also update top-level msgs
+    top_msgs = tx_item.get("msgs") or []
+    for i, m in enumerate(top_msgs):
+        derive_msgs = derive.get("msgs", [])
+        if i < len(derive_msgs):
+            m["sig"] = derive_msgs[i].get("sig", "")
+
+    return json.dumps(derive.get("msgs") or msgs)
+
+
+def _sign_evm_regular(tx_item: dict, social_chain: str, sw) -> str:
+    """Sign a regular EVM tx via Social Login Wallet. Returns signed tx hex."""
+    derive = tx_item.get("deriveTransaction", {})
+    chain_id = derive.get("chainId") or tx_item.get("chainId", 1)
+
+    sign_params = {
+        "chain": social_chain,
+        "chainId": int(chain_id),
+        "to": derive.get("to") or tx_item.get("to", ""),
+        "value": derive.get("value") or tx_item.get("value", 0),
+        "data": derive.get("data") or tx_item.get("data", "0x"),
+        "nonce": int(derive.get("nonce", tx_item.get("nonce", 0))),
+        "gasLimit": str(derive.get("gasLimit", tx_item.get("gasLimit", 0))),
+        "gasPrice": str(derive.get("gasPrice", tx_item.get("gasPrice", "0.000000001"))),
+    }
+
+    result = sw.sign_transaction_return(social_chain, sign_params)
+    return result.get("result", result.get("signature", ""))
+
+
+def _sign_tron(tx_item: dict, sw) -> str:
+    """Sign a Tron tx via Social Login Wallet. Returns JSON string for send API."""
+    derive = tx_item.get("deriveTransaction", {})
+    transaction = derive.get("transaction") or tx_item.get("transaction")
+    if not transaction:
+        raise ValueError("Tron tx missing 'transaction' object")
+
+    sign_params = {"chain": "tron", "transaction": transaction}
+    result = sw.sign_transaction_return("tron", sign_params)
+    sig_hex = result.get("result", result.get("signature", ""))
+
+    # Wrap in format expected by send API
+    sig_obj = {
+        "signature": [sig_hex],
+        "txID": transaction["txID"],
+        "raw_data": transaction["raw_data"],
+    }
+    return json.dumps(sig_obj)
+
+
+def _sign_solana(tx_item: dict, sw) -> str:
+    """Sign a Solana tx via Social Login Wallet. Returns signed tx for send API."""
+    derive = tx_item.get("deriveTransaction") or {}
+
+    # Find serialized transaction
+    serialized_tx = None
+    source = derive.get("source") or tx_item.get("source")
+    if isinstance(source, dict):
+        serialized_tx = source.get("serializedTransaction")
+
+    if not serialized_tx:
+        data = tx_item.get("data", {})
+        if isinstance(data, dict):
+            serialized_tx = data.get("serializedTx") or data.get("serializedTransaction")
+
+    if not serialized_tx:
+        raise ValueError("Cannot find serializedTransaction in Solana tx item")
+
+    # Use signData with serializedTransaction for Social Login Wallet
+    sign_params = {
+        "chain": "sol",
+        "signData": {"serializedTransaction": serialized_tx, "version": "0"},
+    }
+    result = sw.sign_transaction_return("sol", sign_params)
+    return result.get("result", result.get("signature", ""))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Social Login Wallet: makeOrder + sign (TEE) + send in one shot."
+    )
+    parser.add_argument("--wallet-id", required=True, help="Social Login Wallet walletId (from profile)")
+    parser.add_argument("--order-id", required=True, help="From confirm response data.orderId")
+    parser.add_argument("--from-address", required=True)
+    parser.add_argument("--to-address", required=True)
+    parser.add_argument("--from-chain", required=True)
+    parser.add_argument("--from-contract", required=True)
+    parser.add_argument("--from-symbol", required=True)
+    parser.add_argument("--to-chain", required=True)
+    parser.add_argument("--to-contract", default="")
+    parser.add_argument("--to-symbol", required=True)
+    parser.add_argument("--from-amount", required=True)
+    parser.add_argument("--slippage", required=True)
+    parser.add_argument("--market", required=True)
+    parser.add_argument("--protocol", required=True)
+    args = parser.parse_args()
+
+    # Import API module
+    _api = importlib.import_module("bitget-wallet-agent-api")
+
+    # Import social wallet signing functions
+    sw_path = SCRIPTS_DIR / "social-wallet.py"
+    spec = importlib.util.spec_from_file_location("social_wallet", sw_path)
+    sw = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(sw)
+    sw.load_secret()
+    if not sw.APPID or not sw.APPSECRET:
+        print(f"ERROR: Missing Social Login Wallet credentials. Create {sw.SECRET_FILE}", file=sys.stderr)
+        sys.exit(1)
+
+    # Set wallet-id for API calls
+    _api.WALLET_ID = args.wallet_id
+
+    # Step 1: makeOrder
+    print(">>> Step 1: makeOrder", file=sys.stderr)
+    resp = _api.make_order(
+        order_id=args.order_id,
+        from_chain=args.from_chain,
+        from_contract=args.from_contract,
+        from_symbol=args.from_symbol,
+        from_address=args.from_address,
+        to_chain=args.to_chain,
+        to_contract=args.to_contract or "",
+        to_symbol=args.to_symbol,
+        to_address=args.to_address,
+        from_amount=args.from_amount,
+        slippage=args.slippage,
+        market=args.market,
+        protocol=args.protocol,
+    )
+    if resp.get("status") != 0 or resp.get("error_code") != 0:
+        print(json.dumps(resp, indent=2))
+        sys.exit(1)
+
+    data = resp["data"]
+    order_id = data["orderId"]
+    txs = data["txs"]
+    print(f"    orderId: {order_id}, txs: {len(txs)}", file=sys.stderr)
+
+    # Step 2: Sign each tx
+    print(">>> Step 2: sign (Social Login Wallet TEE)", file=sys.stderr)
+
+    for i, tx in enumerate(txs):
+        api_chain = (tx.get("chain") or args.from_chain).lower()
+        social_chain = _get_social_chain(api_chain)
+        derive = tx.get("deriveTransaction") or {}
+        msgs = derive.get("msgs") or tx.get("msgs") or []
+
+        if _is_tron_order({"txs": [tx]}):
+            print(f"    tx[{i}]: Tron signing", file=sys.stderr)
+            tx["sig"] = _sign_tron(tx, sw)
+
+        elif _is_solana_order({"txs": [tx]}):
+            print(f"    tx[{i}]: Solana signing", file=sys.stderr)
+            tx["sig"] = _sign_solana(tx, sw)
+
+        elif msgs and any(m.get("signType") == "eth_sign" for m in msgs):
+            print(f"    tx[{i}]: EVM gasPayMaster ({len(msgs)} msg(s))", file=sys.stderr)
+            tx["sig"] = _sign_evm_gasPayMaster(tx, social_chain, sw)
+
+        else:
+            print(f"    tx[{i}]: EVM regular tx", file=sys.stderr)
+            tx["sig"] = _sign_evm_regular(tx, social_chain, sw)
+
+    # Step 3: Send
+    print(">>> Step 3: send", file=sys.stderr)
+    send_resp = _api.send(order_id=order_id, txs=txs)
+    print(json.dumps(send_resp, indent=2))
+
+    if send_resp.get("status") != 0 or send_resp.get("error_code") != 0:
+        sys.exit(1)
+
+    print(
+        f"\nOrderId: {order_id}\n"
+        f"Check: python3 scripts/bitget-wallet-agent-api.py get-order-details --order-id {order_id}",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `social_order_make_sign_send.py` — a one-shot script that combines makeOrder → sign (TEE) → send for Social Login Wallet, mirroring `order_make_sign_send.py` for mnemonic/private-key wallets.

## Changes

### New: `scripts/social_order_make_sign_send.py`
- Combines makeOrder + sign + send in a single run
- Avoids the ~60s makeOrder data expiry issue
- No local private key needed — signs via Bitget Wallet TEE API
- Auto-detects signing mode:
  - EVM gasPayMaster (gasless, eth_sign hash signing)
  - EVM regular tx (sign_transaction)
  - Solana (sign_transaction with signData)
  - Tron (sign_transaction with transaction object)

### Modified: `scripts/social-wallet.py`
- Added `call_api_return()` — returns decrypted result as dict (no stdout print)
- Added `sign_message_return(chain, message)` — importable message signing
- Added `sign_transaction_return(chain, tx_params)` — importable tx signing
- Original CLI behavior (call_api, main) unchanged

## Testing

BNB Chain gasless swap: 5 USDC → 4.955 USDT (gasPayMaster mode)
- [tx: 0x298b9b52...](https://bscscan.com/tx/0x298b9b52038497261ec2d15a8be87b18af10ae7881427dd618a0d4ecaa1e34fc)