### PR TITLE
fix: Python 3.9 compatibility for social-wallet.py

### DIFF
--- a/scripts/social-wallet.py
+++ b/scripts/social-wallet.py
@@ -4,6 +4,7 @@ Social Login Wallet CLI — sign transactions and messages via Bitget Wallet TEE
 Credentials loaded from .social-wallet-secret (same directory as this script).
 Dependencies: requests, cryptography
 """
+from __future__ import annotations
 
 import base64
 import hashlib


### PR DESCRIPTION
## Problem

`social-wallet.py` uses `dict | None` type hint syntax (PEP 604, line 153) which requires Python 3.10+. The project documents Python 3.9+ compatibility.

Running on Python 3.9:
```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

## Fix

Add `from __future__ import annotations` at the top of `social-wallet.py`. This enables PEP 604 syntax on Python 3.9 without changing any type hints.

One-line change, zero behavior impact.

Fixes #50